### PR TITLE
Move credentials to environment variables

### DIFF
--- a/Compute Console.postman_collection.json
+++ b/Compute Console.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "959507cd-e216-4a02-9695-2cb91a5527e2",
+		"_postman_id": "1375b938-d515-4f65-9a5f-83894da781f4",
 		"name": "Compute Console",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -33,7 +33,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n \"username\":\"ACCESS KEY\",\n \"password\":\"SECRET KEY\"\n}"
+							"raw": "{\n \"username\":\"{{ACCESS_KEY}}\",\n \"password\":\"{{SECRET_KEY}}\"\n}"
 						},
 						"url": {
 							"raw": "{{compute-api-endpoint}}{{console-port}}/api/{{api-version}}/authenticate",

--- a/Prisma Cloud.postman_collection.json
+++ b/Prisma Cloud.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "cdebb92d-9cb0-40e8-824a-56ca07d0335c",
+		"_postman_id": "6847adb7-40ab-4ced-bebe-f4ab8adb1aaa",
 		"name": "Prisma Cloud",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -36,7 +36,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"username\": \"ACCESS KEY\",\n    \"password\": \"SECRET KEY\"\n}"
+							"raw": "{\n    \"username\": \"{{ACCESS_KEY}}\",\n    \"password\": \"{{SECRET_KEY}}\"\n}"
 						},
 						"url": {
 							"raw": "https://{{api-endpoint}}/login",
@@ -1136,7 +1136,7 @@
 							}
 						],
 						"url": {
-							"raw": "https://{{api-endpoint}}/cloud/name?onlyActive=true&accountGroupIds=ACCOUNT_GROUP_ID&cloudType=gcp",
+							"raw": "https://{{api-endpoint}}/cloud/name?onlyActive=true&accountGroupIds=ACCOUNT_GROUP_ID&cloudType=CLOUD_TYPE",
 							"protocol": "https",
 							"host": [
 								"{{api-endpoint}}"

--- a/Prisma Cloud.postman_environment.json
+++ b/Prisma Cloud.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "51b32f17-dacd-40c0-91d0-ed2aba1d802f",
+	"id": "d8e08763-3a02-4b8e-8f82-0eca408ca153",
 	"name": "Prisma Cloud",
 	"values": [
 		{
@@ -31,9 +31,19 @@
 			"key": "console-port",
 			"value": "",
 			"enabled": true
+		},
+		{
+			"key": "ACCESS_KEY",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "SECRET_KEY",
+			"value": "",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-12-02T23:42:23.003Z",
-	"_postman_exported_using": "Postman/7.36.0"
+	"_postman_exported_at": "2021-01-22T20:47:37.803Z",
+	"_postman_exported_using": "Postman/7.36.1"
 }

--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ To use these Collections and Environment, there are a few setup pieces after imp
 
 ![3](./Images/import3.png)
 
-1. Set the Prisma Cloud API and Console URL in the [Postman Environment variable](https://learning.postman.com/docs/sending-requests/variables/)
-
+1. Set some [Postman Environment variables](https://learning.postman.com/docs/sending-requests/variables/). You will need to set:
+    1. api-endpoint
+    1. compute-api-endpoint
+    1. ACCESS_KEY
+    1. SECRET_KEY
 ![1](./Images/Env1.png)
 
 ![2](./Images/Env2.png)
@@ -53,45 +56,6 @@ api-version | Used only for the Compute collection for future API versions | v1
 console-port | Used only for self-hosted versions of the Compute Console | 
 
 
-
-
-# Set your access and secret key in the username and password fields in the BODY of the /login and /authenticate requests.
-These will be the first 2 requests of both Collections under the **Login** folder. 
-* Prisma Cloud API /login BODY example:
-
-`
-{ 
-    "username": "abcde-fghi-jklm-nopq-rstuvwxyz",   
-    "password": "a1b2c3d4e5f6g7h8i9"   
-}
-`
-* There is also an optional parameter to send if you have access to more than 1 Prisma Cloud tenant called *customerName*, example:
-
-`
-{ 
-    "username": "abcde-fghi-jklm-nopq-rstuvwxyz",   
-    "password": "a1b2c3d4e5f6g7h8i9",
-    "customerName": "Company XYZ - 123456"
-}
-`
-* Before
-
-![5](./Images/userpassbefore.png)
-
-* After
-
-
-![6](./Images/userpassafter.png)
-
-* Prisma Cloud Compute Console /authenticate BODY example:
-
-`
-{ 
-    "username": "abcde-fghi-jklm-nopq-rstuvwxyz",   
-    "password": "a1b2c3d4e5f6g7h8i9"   
-}
-`
-
 ## Advanced Postman scenarios using Collection Runner
 
 In the **Collection_Runner** folder, there are specific examples for use-cases where using Postman's Collection Runner makes sense. 
@@ -99,3 +63,6 @@ In the **Collection_Runner** folder, there are specific examples for use-cases w
 This is an easy way to iterate through files/CSVs/etc for a specific subset of API calls you want to make. More instructions in the README within [this folder](https://github.com/PaloAltoNetworks/pcs-postman/tree/main/Collection_Runner).
 
 ## That's it! The Collections are not fully complete, so if you find a request that hasn't been created (or needs updated) please feel free to submit a PR. 
+
+## Accessing Multiple Tenants
+You can easily switch between Prisma Cloud Tenants by creating multiple Environments. To do this just import the `Prisma Cloud.postman_environment.json` file again and set the new api endpoints and credentials. Be sure to change the environment name so you can tell your environments apart! 


### PR DESCRIPTION
## Description
Moves ACCESS KEY and SECRET KEY to environment to support multiple tenants easily

## Motivation and Context
By moving the login credentials we accomplish a few things:
1) Only have to update the access and secret keys in one place instead of doing it in 2 collection login bodies
2) Allows you to create multiple environments to easily switch between tenants without changing credentials

## How Has This Been Tested?
Tested locally in Postman

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have updated the documentation accordingly. (A new screenshot for Images/Env3.png is needed)
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
